### PR TITLE
Refactor portfolio form dialog and position table menu

### DIFF
--- a/libs/client/features/portfolios/src/components/portfolios/portfolio-form-dialog/portfolio-form-dialog.tsx
+++ b/libs/client/features/portfolios/src/components/portfolios/portfolio-form-dialog/portfolio-form-dialog.tsx
@@ -17,11 +17,7 @@ const validationSchema = yup.object().shape({
 
 export function PortfolioFormDialog({ isOpen, onClose, portfolio, onUpdate }: PortfolioFormDialogProps) {
   return (
-    <CommonDialog
-      closeDialog={onClose}
-      dialogTitle={portfolio ? 'Update Portfolio' : 'Close Portfolio'}
-      isOpen={isOpen}
-    >
+    <CommonDialog closeDialog={onClose} dialogTitle={portfolio ? 'Update Portfolio' : 'Add Portfolio'} isOpen={isOpen}>
       <Formik
         initialValues={{
           name: portfolio?.name || '',

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-form-dialog/position-form-dialog.module.scss
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-form-dialog/position-form-dialog.module.scss
@@ -1,0 +1,7 @@
+/*
+ * Replace this with your own classes
+ *
+ * e.g.
+ * .container {
+ * }
+*/

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-form-dialog/position-form-dialog.spec.tsx
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-form-dialog/position-form-dialog.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+
+import PositionFormDialog from './position-form-dialog';
+
+describe('PositionFormDialog', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<PositionFormDialog />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-form-dialog/position-form-dialog.tsx
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-form-dialog/position-form-dialog.tsx
@@ -1,0 +1,69 @@
+import { CommonButton, CommonDialog, FieldInput } from '@avi/client-components';
+import styles from './position-form-dialog.module.scss';
+import { Position } from '@avi/global/models';
+import { Formik } from 'formik';
+import * as yup from 'yup';
+
+export interface PositionFormDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onUpdate: (position: Position) => void;
+  dialogTitle: string;
+}
+
+const validationSchema = yup.object().shape({
+  symbol: yup.string().required('Stock symbol is required'),
+});
+
+export function PositionFormDialog({ isOpen, onClose, onUpdate, dialogTitle }: PositionFormDialogProps) {
+  return (
+    <CommonDialog closeDialog={onClose} dialogTitle={dialogTitle} isOpen={isOpen}>
+      <Formik
+        initialValues={{
+          symbol: '',
+        }}
+        validationSchema={validationSchema}
+        onSubmit={(values, { setSubmitting, resetForm }) => {
+          setSubmitting(false);
+
+          const updatedPosition: Position = {
+            ...values,
+          } as Position;
+
+          onUpdate(updatedPosition);
+
+          onClose();
+          resetForm();
+        }}
+      >
+        {({ touched, errors, isValid, handleSubmit }) => (
+          <form
+            className={styles['form']}
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleSubmit(event);
+            }}
+          >
+            <div className={styles['form-field']}>
+              <label htmlFor="symbol">Symbol</label>
+              <FieldInput type="text" name="symbol" required={true} />
+              {touched.symbol && errors.symbol && (
+                <div style={{ color: 'var(--material-color-red-a700)' }}>{errors.symbol}</div>
+              )}
+            </div>
+            <div className="form-actions">
+              <CommonButton backgroundColor="green" size="small" type="submit" disabled={!isValid}>
+                Update
+              </CommonButton>
+              <CommonButton backgroundColor="grey" size="small" type="button" onClick={onClose}>
+                Cancel
+              </CommonButton>
+            </div>
+          </form>
+        )}
+      </Formik>
+    </CommonDialog>
+  );
+}
+
+export default PositionFormDialog;

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-table-menu-items/position-table-menu-items-button.tsx
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-table-menu-items/position-table-menu-items-button.tsx
@@ -6,7 +6,7 @@ interface ButtonProps {
 
 const PositionViewButton = styled.button<ButtonProps>`
   border: none;
-  background-color: ${(props) => (props.$active ? 'var(--material-color-light-blue-100)' : 'transparent')};
+  background-color: ${(props) => (props.$active ? 'var(--material-color-brown-50)' : 'transparent')};
   text-decoration: none;
   border-radius: 0.5rem;
   cursor: pointer;

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-table-menu.tsx
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-menu/position-table-menu.tsx
@@ -1,17 +1,30 @@
 import { CommonButton } from '@avi/client-components';
 import PositionTableMenuItems from './position-table-menu-items/position-table-menu-items';
 import styles from './position-table-menu.module.scss';
+import { useBoolean } from '@avi/client-hooks';
+import PositionFormDialog from './position-form-dialog/position-form-dialog';
 
 export function PositionTableMenu() {
+  const { setTrue: setModalTrue, setFalse: setModalFalse, value: isModalOpen } = useBoolean(false);
   return (
-    <div className={styles['container']}>
-      <PositionTableMenuItems />
-      <div className={styles['add-new-button']}>
-        <CommonButton backgroundColor="green" size="medium">
-          Add Symbol
-        </CommonButton>
+    <>
+      <div className={styles['container']}>
+        <PositionTableMenuItems />
+        <div className={styles['add-new-button']}>
+          <CommonButton backgroundColor="green" size="medium" onClick={setModalTrue}>
+            Add Symbol
+          </CommonButton>
+        </div>
       </div>
-    </div>
+      <PositionFormDialog
+        isOpen={isModalOpen}
+        onClose={setModalFalse}
+        onUpdate={(position) => {
+          console.log('update', position);
+        }}
+        dialogTitle="Add Symbol"
+      />
+    </>
   );
 }
 

--- a/libs/client/features/portfolios/src/components/positions/positions-top-menu/positions-top-right-menu/positions-top-right-menu.tsx
+++ b/libs/client/features/portfolios/src/components/positions/positions-top-menu/positions-top-right-menu/positions-top-right-menu.tsx
@@ -3,7 +3,7 @@ import styles from './positions-top-right-menu.module.scss';
 export function PositionsTopRightMenu() {
   return (
     <div className={styles['container']}>
-      <div>TODO: Add a new portfolio</div>
+      <div>TODO: Add a new portfolio button</div>
     </div>
   );
 }


### PR DESCRIPTION
- Refactor the portfolio form dialog and position table menu components to improve code readability and maintainability.
- Update the background color of the position view button in the position table menu to use a brown color when active.
- Add a new portfolio button in the positions top right menu.
- Create a position form dialog component for adding and updating positions.
- Implement validation for the symbol field in the position form dialog.