### PR TITLE
Refactor position table menu and add button menu functionality

### DIFF
--- a/libs/client/components/src/misc/index.ts
+++ b/libs/client/components/src/misc/index.ts
@@ -2,3 +2,4 @@ export * from './render-when/render-when';
 export * from './common-dialog/common-dialog';
 export * from './tables';
 export * from './common-toaster/common-toaster';
+export * from './menus/button-menu/button-menu';

--- a/libs/client/components/src/misc/menus/button-menu/button-menu.module.scss
+++ b/libs/client/components/src/misc/menus/button-menu/button-menu.module.scss
@@ -1,0 +1,30 @@
+.container {
+    position: relative;
+    display: inline-block;
+  }
+  
+  .button {
+    padding: 10px 20px;
+    cursor: pointer;
+    background: transparent;
+    border: none;
+  }
+  
+  .menu {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    background-color: white;
+    border: 1px solid #ccc;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+  }
+  
+  .menu-item {
+    padding: 10px 20px;
+    cursor: pointer;
+  
+    &:hover {
+      background-color: #f0f0f0;
+    }
+  }

--- a/libs/client/components/src/misc/menus/button-menu/button-menu.spec.tsx
+++ b/libs/client/components/src/misc/menus/button-menu/button-menu.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+
+import ButtonMenu from './button-menu';
+
+describe('ButtonMenu', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<ButtonMenu />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/client/components/src/misc/menus/button-menu/button-menu.tsx
+++ b/libs/client/components/src/misc/menus/button-menu/button-menu.tsx
@@ -1,0 +1,49 @@
+import React, { useState, useRef } from 'react';
+import { useSpring, animated } from 'react-spring';
+import { useOnClickOutside } from '@avi/client-hooks';
+import styles from './button-menu.module.scss';
+import MenuIcon from '@mui/icons-material/Menu';
+
+import styled from 'styled-components';
+
+export const ButtonMenuItem = styled.div`
+  padding: 10px 20px;
+  cursor: pointer;
+  &:hover {
+    background-color: #f0f0f0;
+  }
+`;
+
+export interface ButtonMenuProps {
+  items: React.ReactNode[];
+}
+
+export function ButtonMenu({ items }: ButtonMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const animation = useSpring({
+    opacity: isOpen ? 1 : 0,
+    transform: isOpen ? `scale(1)` : `scale(0.5)`,
+    transformOrigin: 'center center',
+  });
+
+  useOnClickOutside(menuRef, () => setIsOpen(false));
+
+  return (
+    <div className={styles['container']}>
+      <button onClick={() => setIsOpen(!isOpen)} className={styles['button']} aria-label="Position Menu">
+        <MenuIcon />
+      </button>
+      {isOpen && (
+        <animated.div style={animation} className={styles['menu']} ref={menuRef}>
+          {items.map((item, index) => (
+            <div key={index}>{item}</div>
+          ))}
+        </animated.div>
+      )}
+    </div>
+  );
+}
+
+export default ButtonMenu;

--- a/libs/client/components/src/misc/tables/styled-table.tsx
+++ b/libs/client/components/src/misc/tables/styled-table.tsx
@@ -17,8 +17,18 @@ const TableRow = styled.tr`
   }
 `;
 
-const TableCell = styled.td`
+interface TableCellProps {
+  profitLoss?: number;
+}
+
+const TableCell = styled.td<TableCellProps>`
   padding: 8px;
+  color: ${({ profitLoss }) =>
+    profitLoss && profitLoss > 0
+      ? 'var(--material-color-green-800)'
+      : profitLoss && profitLoss < 0
+      ? 'var(--material-color-red-800)'
+      : 'inherit'};
 `;
 
 const StyledTable: React.FC = () => {

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-header/holdings-table-header.tsx
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-header/holdings-table-header.tsx
@@ -6,6 +6,7 @@ export function HoldingsTableHeader() {
     <thead>
       <TableRow>
         <TableHeader>Symbol</TableHeader>
+        <TableHeader></TableHeader>
         <TableHeader>Name</TableHeader>
         <TableHeader>Shares</TableHeader>
         <TableHeader>Price</TableHeader>

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-table-row.tsx
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-table-row.tsx
@@ -1,8 +1,9 @@
+import { ButtonMenu, TableCell, TableRow } from '@avi/client-components';
 import { Position } from '@avi/global/models';
-import styles from './holdings-table-row.module.scss';
-import { TableCell, TableRow } from '@avi/client-components';
+import { formatCurrency, formatNumber, formatPercentageDivideBy100 } from '@avi/global/services';
 import { Link } from 'react-router-dom';
-import { formatCurrency, formatNumber, formatPercentage } from '@avi/global/services';
+import styles from './holdings-table-row.module.scss';
+import HoldingsTransactionMenu from './holdings-transaction-menu/holdings-transaction-menu';
 
 export interface HoldingsTableRowProps {
   position: Position;
@@ -15,14 +16,19 @@ export function HoldingsTableRow({ position }: HoldingsTableRowProps) {
       <TableCell>
         <Link to={`/positions/${position.symbol}`}>{position.symbol}</Link>{' '}
       </TableCell>
+      <TableCell>
+        <HoldingsTransactionMenu />
+      </TableCell>
       <TableCell>{position.name}</TableCell>
       <TableCell>{formatNumber(position?.shares ?? 0)}</TableCell>
       <TableCell>{formatCurrency(position?.price ?? 0)}</TableCell>
       <TableCell>{formatCurrency(position?.marketValue ?? 0)}</TableCell>
       <TableCell>{formatCurrency(position?.costBasis ?? 0)}</TableCell>
       <TableCell>{formatCurrency(position?.previousClose ?? 0)}</TableCell>
-      <TableCell>{formatCurrency(position?.change ?? 0)}</TableCell>
-      <TableCell>{formatPercentage(position?.changesPercentage ?? 0)}</TableCell>
+      <TableCell profitLoss={position?.change ?? 0}>{formatCurrency(position?.change ?? 0)}</TableCell>
+      <TableCell profitLoss={position?.changesPercentage ?? 0}>
+        {formatPercentageDivideBy100(position?.changesPercentage ?? 0)}
+      </TableCell>
     </TableRow>
   );
 }

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-transaction-menu/holdings-transaction-menu.module.scss
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-transaction-menu/holdings-transaction-menu.module.scss
@@ -1,0 +1,7 @@
+/*
+ * Replace this with your own classes
+ *
+ * e.g.
+ * .container {
+ * }
+*/

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-transaction-menu/holdings-transaction-menu.spec.tsx
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-transaction-menu/holdings-transaction-menu.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+
+import HoldingsTransactionMenu from './holdings-transaction-menu';
+
+describe('HoldingsTransactionMenu', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<HoldingsTransactionMenu />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-transaction-menu/holdings-transaction-menu.tsx
+++ b/libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-transaction-menu/holdings-transaction-menu.tsx
@@ -1,0 +1,13 @@
+import { ButtonMenu, ButtonMenuItem } from '@avi/client-components';
+import styles from './holdings-transaction-menu.module.scss';
+
+export function HoldingsTransactionMenu() {
+  const menuItems = [<ButtonMenuItem>Lots</ButtonMenuItem>, <ButtonMenuItem>Transactions</ButtonMenuItem>];
+  return (
+    <div className={styles['container']}>
+      <ButtonMenu items={menuItems} />
+    </div>
+  );
+}
+
+export default HoldingsTransactionMenu;

--- a/libs/client/hooks/src/use-on-click-outside/on-click-outside.ts
+++ b/libs/client/hooks/src/use-on-click-outside/on-click-outside.ts
@@ -10,7 +10,7 @@ type Handler = (event: MouseEvent) => void;
  * @param handler
  * @param mouseEvent
  */
-function useOnClickOutside<T extends HTMLElement = HTMLElement>(
+export function useOnClickOutside<T extends HTMLElement = HTMLElement>(
   ref: RefObject<T>,
   handler: Handler,
   mouseEvent: 'mousedown' | 'mouseup' = 'mousedown'

--- a/libs/global/services/src/money/format-utl.ts
+++ b/libs/global/services/src/money/format-utl.ts
@@ -17,6 +17,14 @@ export function formatPercentage(number: number): string {
   return formatter.format(number);
 }
 
+export function formatPercentageDivideBy100(number: number): string {
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    minimumFractionDigits: 2,
+  });
+  return formatter.format(number / 100);
+}
+
 export function formatNumber(number: number): string {
   const formatter = new Intl.NumberFormat('en-US');
 


### PR DESCRIPTION
This pull request introduces a new `ButtonMenu` component and integrates it into the holdings table, along with some other enhancements and refactoring. The most important changes include the addition of the `ButtonMenu` component, modifications to the holdings table to include the new menu, and the creation of new utility functions and styles.

### New `ButtonMenu` Component

* [`libs/client/components/src/misc/menus/button-menu/button-menu.tsx`](diffhunk://#diff-d917107e325db8d398b00359bfe74385121ec6757b3310cd15bf70fdd7878221R1-R49): Added a new `ButtonMenu` component with animation and click outside handling.
* [`libs/client/components/src/misc/menus/button-menu/button-menu.module.scss`](diffhunk://#diff-18f9a7c31d087a80eaea37ca1e73224c8681c9e1ebc8a2cdeafa07e64802b35dR1-R30): Added styles for the `ButtonMenu` component.
* [`libs/client/components/src/misc/menus/button-menu/button-menu.spec.tsx`](diffhunk://#diff-008f9e44e14eb96bf66e46d1b0a9575de943363af10c71133167930b4099e39dR1-R10): Added unit tests for the `ButtonMenu` component.

### Holdings Table Enhancements

* [`libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-table-row.tsx`](diffhunk://#diff-f110ed9cfaf6740afd3f1166140ef66c84afc05c01b3f7896c9a75f7e3667440R1-R6): Integrated `ButtonMenu` into the holdings table row and added new `profitLoss` prop to `TableCell` for conditional styling. [[1]](diffhunk://#diff-f110ed9cfaf6740afd3f1166140ef66c84afc05c01b3f7896c9a75f7e3667440R1-R6) [[2]](diffhunk://#diff-f110ed9cfaf6740afd3f1166140ef66c84afc05c01b3f7896c9a75f7e3667440R19-R31)
* [`libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-header/holdings-table-header.tsx`](diffhunk://#diff-870f98ed9dd324925c31c3e124f8fd8105be6935b77aaf4bece744b0fbe74a4cR9): Added an empty header cell for the new menu column.
* [`libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-transaction-menu/holdings-transaction-menu.tsx`](diffhunk://#diff-179d04a183ea5bad07f84bd79a8b70e577ba704da448087a01f200c1639226ecR1-R13): Added `HoldingsTransactionMenu` component to be used within the holdings table.
* [`libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-table-row/holdings-transaction-menu/holdings-transaction-menu.module.scss`](diffhunk://#diff-0fff058d2c4890497797d4d07cd0345982552bdee0e8ca664cd89c046bd3fe42R1-R7): Added placeholder styles for the `HoldingsTransactionMenu`.
* [`libs/client/features/portfolios/src/components/positions/positions-table-container/position-table-selector/holdings-table/holdings-transaction-menu/holdings-transaction-menu.spec.tsx`](diffhunk://#diff-797f2f3bce2c59113df6f9f69d069245fd83b1e43e418dafbf0731638b4d35ccR1-R10): Added unit tests for the `HoldingsTransactionMenu` component.

### Utility Functions and Refactoring

* [`libs/global/services/src/money/format-utl.ts`](diffhunk://#diff-841a6e0b9bca85bd11ce8507bf48b3ee255586814303d0ba0510217d4286e04cR20-R27): Added `formatPercentageDivideBy100` function for formatting percentages.
* [`libs/client/hooks/src/use-on-click-outside/on-click-outside.ts`](diffhunk://#diff-081b4be25ccc90ba4f0eac7dc00ba4c4e35c4723a037b1c86e90963edc2ca587L13-R13): Exported `useOnClickOutside` hook to be used in the `ButtonMenu` component.
* [`libs/client/components/src/misc/tables/styled-table.tsx`](diffhunk://#diff-3c676fae52ee59b433aa8984a3b83113f3b6eeb48ebe0fadbbd3bc067c611db8L20-R31): Added `profitLoss` prop to `TableCell` for conditional color styling.
* [`libs/client/components/src/misc/index.ts`](diffhunk://#diff-5a6cb39ad82b106fa5f12101a5e8c082e883af2dfe444d8c51150eaeaf530951R5): Exported `ButtonMenu` from the `misc` components index.