### PR TITLE
refactor(components): Update summary cells and money services

### DIFF
--- a/libs/client/components/src/misc/index.ts
+++ b/libs/client/components/src/misc/index.ts
@@ -3,3 +3,4 @@ export * from './common-dialog/common-dialog';
 export * from './tables';
 export * from './common-toaster/common-toaster';
 export * from './menus/button-menu/button-menu';
+export * from './summary-cells';

--- a/libs/client/components/src/misc/summary-cells/index.ts
+++ b/libs/client/components/src/misc/summary-cells/index.ts
@@ -1,0 +1,2 @@
+export * from './summary-label';
+export * from './summary-detail';

--- a/libs/client/components/src/misc/summary-cells/summary-detail.tsx
+++ b/libs/client/components/src/misc/summary-cells/summary-detail.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+import { HTMLAttributes } from 'react';
+
+export interface SummaryDetailProps extends HTMLAttributes<HTMLHeadingElement> {
+  profitEvenLoss?: 'profit' | 'even' | 'loss';
+}
+
+export const SummaryDetail = styled.h5<SummaryDetailProps>`
+  font-weight: 300;
+  font-size: 1.2rem;
+  color: ${(props: SummaryDetailProps) => {
+    switch (props.profitEvenLoss) {
+      case 'profit':
+        return 'var(--material-color-green-800)';
+      case 'even':
+        return 'var(--material-color-blue-grey-800)';
+      case 'loss':
+        return 'var(--material-color-red-800)';
+      default:
+        return 'var(--material-color-blue-grey-800)';
+    }
+  }};
+`;

--- a/libs/client/components/src/misc/summary-cells/summary-label.tsx
+++ b/libs/client/components/src/misc/summary-cells/summary-label.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const SummaryLabel = styled.h5`
+  font-weight: 800;
+  font-size: 0.8rem;
+`;

--- a/libs/client/features/portfolios/src/components/lots/lots-stock-summary/lots-stock-summary.tsx
+++ b/libs/client/features/portfolios/src/components/lots/lots-stock-summary/lots-stock-summary.tsx
@@ -1,8 +1,8 @@
-import { LargePanel } from '@avi/client-components';
+import { LargePanel, SummaryDetail, SummaryLabel } from '@avi/client-components';
 import { selectPositionGainLoss, selectPositionsDictionary, useAppSelector } from '@avi/client-store';
 import { useParams } from 'react-router-dom';
 import styles from './lots-stock-summary.module.scss';
-import { formatCurrency, formatCurrencyAndPercentage, formatNumber } from '@avi/global/services';
+import { formatCurrency, formatCurrencyAndPercentage, formatNumber, isProfitEvenLoss } from '@avi/global/services';
 
 export function LotsStockSummary() {
   const { symbol, portfolioId } = useParams<{ symbol: string; portfolioId: string }>();
@@ -18,34 +18,34 @@ export function LotsStockSummary() {
           <h2 className={styles['name']}>NVIDIA Corporation</h2>
         </div>
         <div className={styles['price']}>
-          <h5 className={styles['cell-heading']}>Price</h5>
-          <h5 className={styles['cell-detail']}>{formatCurrency(position?.price ?? 0)}</h5>
+          <SummaryLabel> Price</SummaryLabel>
+          <SummaryDetail>{formatCurrency(position?.price ?? 0)}</SummaryDetail>
         </div>
         <div className={styles['shares']}>
-          <h5 className={styles['cell-heading']}>Shares</h5>
-          <h5 className={styles['cell-detail']}>{formatNumber(position?.shares ?? 0)}</h5>
+          <SummaryLabel> Shares</SummaryLabel>
+          <SummaryDetail>{formatNumber(position?.shares ?? 0)}</SummaryDetail>
         </div>
         <div className={styles['avg-cost']}>
-          <h5 className={styles['cell-heading']}>Avg Cost</h5>
-          <h5 className={styles['cell-detail']}>{formatCurrency(position?.averageCostBasis ?? 0)}</h5>
+          <SummaryLabel> Average Cost</SummaryLabel>
+          <SummaryDetail>{formatCurrency(position?.averageCostBasis ?? 0)}</SummaryDetail>
         </div>
         <div className={styles['unrealized']}>
-          <h5 className={styles['cell-heading']}>Unrealized Gains</h5>
-          <h5 className={styles['cell-detail']}>
+          <SummaryLabel> Unrealized Gains</SummaryLabel>
+          <SummaryDetail profitEvenLoss={isProfitEvenLoss(positionGainLoss?.gainLoss)}>
             {formatCurrencyAndPercentage(positionGainLoss?.gainLoss ?? 0, positionGainLoss?.gainLossPercentage ?? 0)}
-          </h5>
+          </SummaryDetail>
         </div>
         <div className={styles['realized']}>
-          <h5 className={styles['cell-heading']}>Realized Gains</h5>
-          <h5 className={styles['cell-detail']}>$5,000 (5.0%)</h5>
+          <SummaryLabel> Realized Gains</SummaryLabel>
+          <SummaryDetail profitEvenLoss={'even'}>$0 (0.0%)</SummaryDetail>
         </div>
         <div className={styles['total']}>
-          <h5 className={styles['cell-heading']}>Total Cost Basis</h5>
-          <h5 className={styles['cell-detail']}>{formatCurrency(position?.totalCostBasis ?? 0)}</h5>
+          <SummaryLabel> Total Cost Basis</SummaryLabel>
+          <SummaryDetail>{formatCurrency(position?.totalCostBasis ?? 0)}</SummaryDetail>
         </div>
         <div className={styles['market']}>
-          <h5 className={styles['cell-heading']}>Market Value</h5>
-          <h5 className={styles['cell-detail']}>{formatCurrency((position?.price ?? 0) * (position?.shares ?? 0))}</h5>
+          <SummaryLabel> Market Value</SummaryLabel>
+          <SummaryDetail>{formatCurrency((position?.price ?? 0) * (position?.shares ?? 0))}</SummaryDetail>
         </div>
       </div>
     </LargePanel>

--- a/libs/client/features/portfolios/src/components/lots/lots-stock-table/lot-stock-table-body/lot-stock-table-body.tsx
+++ b/libs/client/features/portfolios/src/components/lots/lots-stock-table/lot-stock-table-body/lot-stock-table-body.tsx
@@ -46,6 +46,7 @@ export function LotStockTableBody() {
         <RenderWhen.If isTrue={loadingStatus !== 'loading' && !!lots}>
           {(lots ?? [])
             .filter((f) => f.portfolioId === portfolioId && f.symbol === symbol)
+            .sort((a, b) => new Date(b.openDate).getTime() - new Date(a.openDate).getTime())
             .map((lot) => (
               <LotStockTableRow key={lot.id} lot={lot} position={position} />
             ))}

--- a/libs/client/features/portfolios/src/components/lots/lots-stock-table/lot-stock-table-header/lot-stock-table-header.tsx
+++ b/libs/client/features/portfolios/src/components/lots/lots-stock-table/lot-stock-table-header/lot-stock-table-header.tsx
@@ -6,6 +6,7 @@ export function LotStockTableHeader() {
     <thead>
       <TableRow>
         <TableHeader>Open Date</TableHeader>
+        <TableHeader>Trans Type</TableHeader>
         <TableHeader>Shares +/-</TableHeader>
         <TableHeader>Price</TableHeader>
         <TableHeader>Cost/Share</TableHeader>

--- a/libs/client/features/portfolios/src/components/lots/lots-stock-table/lot-stock-table-row/lot-stock-table-row.tsx
+++ b/libs/client/features/portfolios/src/components/lots/lots-stock-table/lot-stock-table-row/lot-stock-table-row.tsx
@@ -1,13 +1,14 @@
 import { Lot, Position } from '@avi/global/models';
 import styles from './lot-stock-table-row.module.scss';
 import { TableCell, TableRow } from '@avi/client-components';
-import { format, FormatOptions } from 'date-fns';
+import { format, FormatOptions, isAfter, set } from 'date-fns';
 import {
   formatCurrency,
   formatCurrencyAndPercentage,
   formatDateAsDayMonthYear,
   formatNumber,
 } from '@avi/global/services';
+import { useEffect, useState } from 'react';
 
 export interface LotStockTableRowProps {
   lot: Lot;
@@ -15,18 +16,34 @@ export interface LotStockTableRowProps {
 }
 
 export function LotStockTableRow({ lot, position }: LotStockTableRowProps) {
+  const [costBasis, setCostBasis] = useState<number>(0);
+  const [gainLoss, setGainLoss] = useState<number>(0);
+  const [gainLossPercentage, setGainLossPercentage] = useState<number>(0);
+  const [marketValue, setMarketValue] = useState<number>(0);
+
+  useEffect(() => {
+    console.log('lot', lot);
+    setMarketValue((position?.price ?? 0) * (lot?.shares ?? 0));
+    setCostBasis((lot?.costPerShare ?? 0) * (lot?.shares ?? 0));
+    setGainLoss((marketValue ?? 0) - costBasis);
+    setGainLossPercentage(gainLoss / costBasis);
+  }, [costBasis, gainLoss, lot, marketValue, position?.price]);
+
   return (
     <TableRow key={lot.id} className={styles.row}>
       <TableCell>{format(lot.openDate, 'MM/dd/yyyy')}</TableCell>
+      <TableCell>{lot.transactionType}</TableCell>
       <TableCell>{formatNumber(lot?.shares ?? 0)}</TableCell>
       <TableCell>{formatCurrency(position?.price ?? 0)}</TableCell>
       <TableCell>{formatCurrency(lot?.costPerShare ?? 0)}</TableCell>
-      <TableCell>{formatCurrency(lot?.marketValue ?? 0)}</TableCell>
-      <TableCell>{formatCurrency(lot?.costBasis ?? 0)}</TableCell>
-      <TableCell $profitLoss={lot?.gainsLosses ?? 0}>
-        {formatCurrencyAndPercentage(lot?.gainsLosses ?? 0, lot?.gainsLossesPercentage ?? 0)}
+      <TableCell>{formatCurrency(marketValue)}</TableCell>
+      <TableCell>{formatCurrency(costBasis)}</TableCell>
+      <TableCell $profitLoss={gainLoss}>{formatCurrencyAndPercentage(gainLoss, gainLossPercentage)}</TableCell>
+      <TableCell>
+        {isAfter(new Date(), new Date(lot.openDate).setFullYear(new Date(lot.openDate).getFullYear() + 1))
+          ? 'LONG'
+          : 'SHORT'}
       </TableCell>
-      <TableCell>{lot?.holdingPeriod}</TableCell>
     </TableRow>
   );
 }

--- a/libs/global/services/src/money/index.ts
+++ b/libs/global/services/src/money/index.ts
@@ -1,2 +1,3 @@
 export * from './cost-bases';
 export * from './format-utl';
+export * from './profit-event-loss';

--- a/libs/global/services/src/money/profit-event-loss.ts
+++ b/libs/global/services/src/money/profit-event-loss.ts
@@ -1,0 +1,13 @@
+export type ProfitEvenLossType = 'profit' | 'even' | 'loss';
+
+export const isProfitEvenLoss = (profit?: number): ProfitEvenLossType => {
+  if (!profit) return 'even';
+
+  if (profit > 0) {
+    return 'profit';
+  } else if (profit < 0) {
+    return 'loss';
+  } else {
+    return 'even';
+  }
+};

--- a/libs/global/services/src/utils/color.ts
+++ b/libs/global/services/src/utils/color.ts
@@ -1,3 +1,14 @@
+/**
+ * Computes the actual color value of a given CSS color variable.
+ *
+ * This function creates a temporary HTML element, applies the provided color variable
+ * as its background color, appends the element to the document body, and then retrieves
+ * the computed background color value. Finally, it removes the temporary element from
+ * the document body and returns the computed color value.
+ *
+ * @param colorVar - The CSS color variable to compute.
+ * @returns The computed color value as a string.
+ */
 export const getComputedColor = (colorVar: string): string => {
   const tempElement = document.createElement('div');
   tempElement.style.backgroundColor = colorVar;

--- a/libs/server/features/portfolios/src/controllers/lots.controller.ts
+++ b/libs/server/features/portfolios/src/controllers/lots.controller.ts
@@ -23,7 +23,8 @@ export const getLotsByStockSymbol = async (req: Request, res: Response) => {
   const symbol = req.params['symbol'] as string;
   try {
     const lots = await lotsSchema.find({ user, portfolioId, symbol });
-    res.status(StatusCodes.OK).json(lots ?? []);
+    const lotsWithId = lots.map((lot) => ({ ...lot.toJSON(), id: lot._id }));
+    res.status(StatusCodes.OK).json(lotsWithId ?? []);
   } catch (error) {
     console.error(error);
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: 'Internal server error' });


### PR DESCRIPTION
- Update summary cells to include summary label and detail components
- Add profit-event-loss module to money services
- Update lot stock table header to include transaction type column
- Update lot stock table body to calculate cost basis, gain/loss, and market value
- Add summary cells module to misc index
- Add profit-event-loss module to money index
- Update lots controller to include lot id in response
- Update color utils to include getComputedColor function
- Update lot stock table row to calculate gain/loss percentage and holding period

This pull request introduces several updates to the `libs/client/components`, `libs/client/features/portfolios`, and `libs/global/services` directories. The changes include new components for summary cells, enhancements to the stock summary and table components, and utility functions for handling profit/loss calculations and color computations. Below are the most important changes:

### Component Enhancements:

* [`libs/client/components/src/misc/index.ts`](diffhunk://#diff-5a6cb39ad82b106fa5f12101a5e8c082e883af2dfe444d8c51150eaeaf530951R6): Added export for `summary-cells` components.
* [`libs/client/components/src/misc/summary-cells/index.ts`](diffhunk://#diff-ab539e857c07935daa054956d32dca2d42e71a8b12ff18f23d416d4f600f24a3R1-R2): Introduced exports for `summary-label` and `summary-detail` components.
* [`libs/client/components/src/misc/summary-cells/summary-detail.tsx`](diffhunk://#diff-dd867adbd712968a959f00f2535a10066de8e87bf8567a0da07dce4a2ea1f560R1-R24): Created `SummaryDetail` component with styled attributes for profit, even, and loss.
* [`libs/client/components/src/misc/summary-cells/summary-label.tsx`](diffhunk://#diff-08cec4883a678e3e2e4e26e723f0fb98f0818b17b5f45280b5be6ffc848e9313R1-R6): Created `SummaryLabel` component with styled attributes.

### Stock Summary and Table Updates:

* [`libs/client/features/portfolios/src/components/lots/lots-stock-summary/lots-stock-summary.tsx`](diffhunk://#diff-4d1cb4b2c234cfc09ec44269f58a48facbf1828d938e551c6a544c9a0fe3bb1eL1-R5): Integrated `SummaryLabel` and `SummaryDetail` components, replacing existing `h5` elements. [[1]](diffhunk://#diff-4d1cb4b2c234cfc09ec44269f58a48facbf1828d938e551c6a544c9a0fe3bb1eL1-R5) [[2]](diffhunk://#diff-4d1cb4b2c234cfc09ec44269f58a48facbf1828d938e551c6a544c9a0fe3bb1eL21-R48)
* [`libs/client/features/portfolios/src/components/lots/lots-stock-table/lot-stock-table-body/lot-stock-table-body.tsx`](diffhunk://#diff-87923b3e52790c96160b89ad6e1dba767fcab21002287f5f6f593cb7de4a3a93R49): Added sorting by `openDate` for lots.
* [`libs/client/features/portfolios/src/components/lots/lots-stock-table/lot-stock-table-header/lot-stock-table-header.tsx`](diffhunk://#diff-4452e19f1ddd2350ff8a9535485b43900458c4e8db81942be22d4d7d390cb70eR9): Added a new column for transaction type.
* [`libs/client/features/portfolios/src/components/lots/lots-stock-table/lot-stock-table-row/lot-stock-table-row.tsx`](diffhunk://#diff-ddbefc7460a99d7b1a0725d70dada7cc63abf3ea16314c75195ee08a4c88b7a4L4-L29): Added state management for cost basis, gain/loss, and market value calculations.

### Utility Functions:

* [`libs/global/services/src/money/index.ts`](diffhunk://#diff-1d15b8039c0cccd24393e739f405cc307510ab7f801283c9ef38eb31b399ce98R3): Added export for `profit-event-loss` utility.
* [`libs/global/services/src/money/profit-event-loss.ts`](diffhunk://#diff-024cb5788f798e4647162f094d4ab3945ff4b85f116cf801e604d920dfe0e6efR1-R13): Introduced `isProfitEvenLoss` function to determine profit, even, or loss states.
* [`libs/global/services/src/utils/color.ts`](diffhunk://#diff-707a66b81a567f248e57986dfedf820915b46861c7f24753d9e9cd77173e2543R1-R11): Added `getComputedColor` function to compute actual color values from CSS variables.

### Backend Enhancements:

* [`libs/server/features/portfolios/src/controllers/lots.controller.ts`](diffhunk://#diff-54296f5827de5d4fe922226e933bfc6ede50de3136d819361e5cf16e44d24844L26-R27): Enhanced `getLotsByStockSymbol` to include `id` in the response.