### PR TITLE
refactor(components): Update SummaryDetail props naming convention

### DIFF
--- a/libs/client/components/src/misc/summary-cells/summary-detail.tsx
+++ b/libs/client/components/src/misc/summary-cells/summary-detail.tsx
@@ -3,14 +3,14 @@ import styled from 'styled-components';
 import { HTMLAttributes } from 'react';
 
 export interface SummaryDetailProps extends HTMLAttributes<HTMLHeadingElement> {
-  profitEvenLoss?: 'profit' | 'even' | 'loss';
+  $profitEvenLoss?: 'profit' | 'even' | 'loss';
 }
 
 export const SummaryDetail = styled.h5<SummaryDetailProps>`
   font-weight: 300;
   font-size: 1.2rem;
   color: ${(props: SummaryDetailProps) => {
-    switch (props.profitEvenLoss) {
+    switch (props.$profitEvenLoss) {
       case 'profit':
         return 'var(--material-color-green-800)';
       case 'even':

--- a/libs/client/features/portfolios/src/components/lots/lots-stock-action-row/lots-stock-action-row.tsx
+++ b/libs/client/features/portfolios/src/components/lots/lots-stock-action-row/lots-stock-action-row.tsx
@@ -2,9 +2,18 @@ import { CommonButton, LargePanel } from '@avi/client-components';
 import styles from './lots-stock-action-row.module.scss';
 import LotFormDialog from './lot-form-dialog/lot-form-dialog';
 import { useBoolean } from '@avi/client-hooks';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useCallback } from 'react';
 
 export function LotsStockActionRow() {
   const { setFalse, setTrue, value: isOpen } = useBoolean(false);
+  const { portfolioId } = useParams();
+  const navigate = useNavigate();
+
+  const handleGoBack = useCallback(() => {
+    navigate(`/positions/${portfolioId}`);
+  }, [navigate, portfolioId]);
+
   return (
     <>
       <LargePanel>
@@ -14,7 +23,9 @@ export function LotsStockActionRow() {
           </CommonButton>
           <CommonButton backgroundColor="blue">Add Dividend</CommonButton>
           <CommonButton backgroundColor="blue">Stock Split</CommonButton>
-          <CommonButton backgroundColor="red">Cancel</CommonButton>
+          <CommonButton backgroundColor="grey" onClick={handleGoBack}>
+            Back
+          </CommonButton>
         </div>
       </LargePanel>
       <LotFormDialog isOpen={isOpen} onClose={setFalse} />

--- a/libs/client/features/portfolios/src/components/lots/lots-stock-summary/lots-stock-summary.tsx
+++ b/libs/client/features/portfolios/src/components/lots/lots-stock-summary/lots-stock-summary.tsx
@@ -31,13 +31,13 @@ export function LotsStockSummary() {
         </div>
         <div className={styles['unrealized']}>
           <SummaryLabel> Unrealized Gains</SummaryLabel>
-          <SummaryDetail profitEvenLoss={isProfitEvenLoss(positionGainLoss?.gainLoss)}>
+          <SummaryDetail $profitEvenLoss={isProfitEvenLoss(positionGainLoss?.gainLoss)}>
             {formatCurrencyAndPercentage(positionGainLoss?.gainLoss ?? 0, positionGainLoss?.gainLossPercentage ?? 0)}
           </SummaryDetail>
         </div>
         <div className={styles['realized']}>
           <SummaryLabel> Realized Gains</SummaryLabel>
-          <SummaryDetail profitEvenLoss={'even'}>$0 (0.0%)</SummaryDetail>
+          <SummaryDetail $profitEvenLoss={'even'}>$0 (0.0%)</SummaryDetail>
         </div>
         <div className={styles['total']}>
           <SummaryLabel> Total Cost Basis</SummaryLabel>

--- a/libs/global/models/src/portfolio.model.ts
+++ b/libs/global/models/src/portfolio.model.ts
@@ -9,7 +9,8 @@ export interface Portfolio {
   updatedAt?: Date;
   isActive?: boolean;
   totalSymbols?: number;
-  totalCostBases?: number;
+  totalCostBasis?: number;
+  averageCostBasis?: number;
   dayChange?: {
     amount: number;
     percentage: number;

--- a/libs/server/features/portfolios/src/controllers/portfolios.controller.ts
+++ b/libs/server/features/portfolios/src/controllers/portfolios.controller.ts
@@ -117,7 +117,7 @@ const mapPortfolio: MapPortfolioType = (portfolio: Portfolio): Portfolio => {
       longTerm: longTermUnrealized,
     },
     positions: portfolio.positions,
-    totalCostBases: portfolio.totalCostBases,
+    totalCostBasis: portfolio.totalCostBasis,
     dayChange: portfolio.dayChange,
   };
 };

--- a/libs/server/features/portfolios/src/schemas/portfolio.schema.ts
+++ b/libs/server/features/portfolios/src/schemas/portfolio.schema.ts
@@ -8,6 +8,8 @@ const portfolioSchema = new Schema<Portfolio>({
   user: { type: String, required: true },
   createdAt: { type: Date, default: Date.now, required: true },
   updatedAt: { type: Date, required: false },
+  totalCostBasis: { type: Number, default: 0 },
+  averageCostBasis: { type: Number, default: 0 },
 });
 
 export default mongoose.model<Portfolio>('Portfolio', portfolioSchema);


### PR DESCRIPTION
This pull request includes several changes across multiple files to enhance the handling of portfolio data, improve navigation, and refine component properties. The most important changes include updating the `SummaryDetail` component property, adding navigation functionality to the `LotsStockActionRow` component, and modifying the portfolio schema and related calculations.

### Component Updates:

* [`libs/client/components/src/misc/summary-cells/summary-detail.tsx`](diffhunk://#diff-dd867adbd712968a959f00f2535a10066de8e87bf8567a0da07dce4a2ea1f560L6-R13): Renamed the `profitEvenLoss` property to `$profitEvenLoss` in the `SummaryDetail` component and its usage.
* [`libs/client/features/portfolios/src/components/lots/lots-stock-summary/lots-stock-summary.tsx`](diffhunk://#diff-4d1cb4b2c234cfc09ec44269f58a48facbf1828d938e551c6a544c9a0fe3bb1eL34-R40): Updated the `SummaryDetail` component to use the `$profitEvenLoss` property.

### Navigation Enhancements:

* [`libs/client/features/portfolios/src/components/lots/lots-stock-action-row/lots-stock-action-row.tsx`](diffhunk://#diff-e30c16ea7ed5b6bb9f56d51807b149e5375826d9a0d1b23ae9b3d60ba5f4c9feR5-R16): Added navigation using `useNavigate` and `useParams` from `react-router-dom`, and replaced the "Cancel" button with a "Back" button that navigates to the previous page. [[1]](diffhunk://#diff-e30c16ea7ed5b6bb9f56d51807b149e5375826d9a0d1b23ae9b3d60ba5f4c9feR5-R16) [[2]](diffhunk://#diff-e30c16ea7ed5b6bb9f56d51807b149e5375826d9a0d1b23ae9b3d60ba5f4c9feL17-R28)

### Schema and Calculation Updates:

* [`libs/global/models/src/portfolio.model.ts`](diffhunk://#diff-5d62c7520db13f535771b72bae3f15ee7811c7ad658072e39a077cf38e0c4458L12-R13): Renamed `totalCostBases` to `totalCostBasis` and added `averageCostBasis` to the `Portfolio` interface.
* [`libs/server/features/portfolios/src/controllers/portfolios.controller.ts`](diffhunk://#diff-e32241ffebf996d45742367b69662c092c0aeb380d1c06e5a30ae2746957b36aL120-R120): Updated the `mapPortfolio` function to reflect the renaming of `totalCostBases` to `totalCostBasis`.
* [`libs/server/features/portfolios/src/schemas/lots.schema.ts`](diffhunk://#diff-d19be955fbf3968e48246b06ba1cc881a4a7522c4649f964dca9e123c610c9ebL30-R81): Modified the `lotsSchema` post-save hook to update `totalCostBasis` and `averageCostBasis` for both the portfolio and individual positions.
* [`libs/server/features/portfolios/src/schemas/portfolio.schema.ts`](diffhunk://#diff-50f9d238e0c5d53a1e4d2c8d47a7b570bf4423e84026861e69e4ee319806dbd0R11-R12): Added `totalCostBasis` and `averageCostBasis` fields to the `portfolioSchema`.